### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,33 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server_terminals/compare/0.0.1...c849eb024b37e98004f9f2038a19d2227d0923a4))
+
+### Enhancements made
+
+- update last_activity when pty_read [#4](https://github.com/jupyter-server/jupyter_server_terminals/pull/4) ([@Wh1isper](https://github.com/Wh1isper))
+- Refactor terminals into an ExtensionApp [#2](https://github.com/jupyter-server/jupyter_server_terminals/pull/2) ([@Zsailer](https://github.com/Zsailer))
+
+### Bugs fixed
+
+- Pin pywintpy and add missing documentation page [#6](https://github.com/jupyter-server/jupyter_server_terminals/pull/6) ([@blink1073](https://github.com/blink1073))
+
+### Maintenance and upkeep improvements
+
+- More Cleanup [#8](https://github.com/jupyter-server/jupyter_server_terminals/pull/8) ([@blink1073](https://github.com/blink1073))
+- Clean up dependencies [#7](https://github.com/jupyter-server/jupyter_server_terminals/pull/7) ([@blink1073](https://github.com/blink1073))
+- Initial setup [#1](https://github.com/jupyter-server/jupyter_server_terminals/pull/1) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Fix links in readme [#3](https://github.com/jupyter-server/jupyter_server_terminals/pull/3) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server_terminals/graphs/contributors?from=2021-12-26&to=2022-04-02&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_terminals+involves%3Ablink1073+updated%3A2021-12-26..2022-04-02&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_terminals+involves%3Ajweill-aws+updated%3A2021-12-26..2022-04-02&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_terminals+involves%3Awelcome+updated%3A2021-12-26..2022-04-02&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_terminals+involves%3AWh1isper+updated%3A2021-12-26..2022-04-02&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_terminals+involves%3AZsailer+updated%3A2021-12-26..2022-04-02&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_server_terminals  |
| Branch  | main  |
| Version Spec | next |
| Since | 0.0.1 |