### PR TITLE
Allow to pass string as a shell override

### DIFF
--- a/jupyter_server_terminals/app.py
+++ b/jupyter_server_terminals/app.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import sys
 from shutil import which
 
@@ -42,6 +43,8 @@ class TerminalsExtensionApp(ExtensionApp):
         else:
             default_shell = which("sh")  # type:ignore[assignment]
         shell_override = self.serverapp.terminado_settings.get("shell_command")
+        if isinstance(shell_override, str):
+            shell_override = shlex.split(shell_override)
         shell = (
             [os.environ.get("SHELL") or default_shell] if shell_override is None else shell_override
         )


### PR DESCRIPTION
Relates to https://github.com/jupyterlab/jupyterlab/issues/12540.

I _think_ that for many users passing a sting may be more convenient and for majority (if not all) `shlex.split` should do the job well.

It will require a follow up PR in `jupyter_server` to change:

```
terminado_settings = Dict(List())
```

(once https://github.com/jupyter-server/jupyter_server/pull/949 gets merged) into

```
terminado_settings = Dict(Union(List(), Unicode()))
```