### PR TITLE
Fix respecting serverapp.terminals_enabled

### DIFF
--- a/jupyter_server_terminals/app.py
+++ b/jupyter_server_terminals/app.py
@@ -36,6 +36,8 @@ class TerminalsExtensionApp(ExtensionApp):
 
     def initialize_settings(self) -> None:
         """Initialize settings."""
+        if not self.serverapp.terminals_enabled:
+            return
         self.initialize_configurables()
         self.settings.update(
             {"terminals_available": True, "terminal_manager": self.terminal_manager}
@@ -70,6 +72,9 @@ class TerminalsExtensionApp(ExtensionApp):
 
     def initialize_handlers(self) -> None:
         """Initialize handlers."""
+        if not self.serverapp.terminals_enabled:
+            # Checking self.terminals_available instead breaks enabling terminals
+            return
         self.handlers.append(
             (
                 r"/terminals/websocket/(\w+)",


### PR DESCRIPTION
Fixes #85 by @rprater

# Before

- Enabling terminals work
- Disabling terminals does nothing

# After

- Enabling terminals still works as tested by creating a new terminal.
- Disabling terminals works now as documented. The "Terminal" menu item in "File > New" is gone and the `terminals(/1?)?` URL is too.
- Omitting the config line still defaults to enabling terminals as expected
- There is no stacktrace unlike uninstalling terminado