### PR TITLE
Set terminals_available to False when not enabled

### DIFF
--- a/jupyter_server_terminals/app.py
+++ b/jupyter_server_terminals/app.py
@@ -74,9 +74,11 @@ class TerminalsExtensionApp(ExtensionApp):
 
     def initialize_handlers(self) -> None:
         """Initialize handlers."""
-        if not self.serverapp or not self.serverapp.terminals_enabled:
+        if not self.serverapp:
             # Checking self.terminals_available instead breaks enabling terminals
+            return
 
+        if not self.serverapp.terminals_enabled:
             # webapp settings for backwards compat (used by nbclassic), #12
             self.serverapp.web_app.settings["terminals_available"] = self.settings[
                 "terminals_available"

--- a/jupyter_server_terminals/app.py
+++ b/jupyter_server_terminals/app.py
@@ -75,7 +75,7 @@ class TerminalsExtensionApp(ExtensionApp):
     def initialize_handlers(self) -> None:
         """Initialize handlers."""
         if not self.serverapp:
-            # Checking self.terminals_available instead breaks enabling terminals
+            # Already set `terminals_available` as `False` in `initialize_settings`
             return
 
         if not self.serverapp.terminals_enabled:

--- a/jupyter_server_terminals/app.py
+++ b/jupyter_server_terminals/app.py
@@ -37,6 +37,7 @@ class TerminalsExtensionApp(ExtensionApp):
     def initialize_settings(self) -> None:
         """Initialize settings."""
         if not self.serverapp or not self.serverapp.terminals_enabled:
+            self.settings.update({"terminals_available": False})
             return
         self.initialize_configurables()
         self.settings.update(
@@ -75,6 +76,11 @@ class TerminalsExtensionApp(ExtensionApp):
         """Initialize handlers."""
         if not self.serverapp or not self.serverapp.terminals_enabled:
             # Checking self.terminals_available instead breaks enabling terminals
+
+            # webapp settings for backwards compat (used by nbclassic), #12
+            self.serverapp.web_app.settings["terminals_available"] = self.settings[
+                "terminals_available"
+            ]
             return
         self.handlers.append(
             (

--- a/tests/test_disable_app.py
+++ b/tests/test_disable_app.py
@@ -1,0 +1,13 @@
+import pytest
+from traitlets.config.loader import Config
+
+
+@pytest.fixture()
+def jp_server_config():
+    return Config({"ServerApp": {"terminals_enabled": False}})
+
+
+async def test_not_enabled(jp_configurable_serverapp):
+    assert jp_configurable_serverapp().terminals_enabled is False
+    assert jp_configurable_serverapp().web_app.settings["terminals_available"] is False
+    assert "terminal_manager" not in jp_configurable_serverapp().web_app.settings

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -236,6 +236,12 @@ async def test_terminal_create_with_bad_cwd(jp_fetch, jp_ws_fetch):
     assert non_existing_path not in message_stdout
 
 
+async def test_app_config(jp_configurable_serverapp):
+    assert jp_configurable_serverapp().terminals_enabled is True
+    assert jp_configurable_serverapp().web_app.settings["terminals_available"] is True
+    assert jp_configurable_serverapp().web_app.settings["terminal_manager"]
+
+
 async def test_culling_config(jp_configurable_serverapp):
     terminal_mgr_config = jp_configurable_serverapp().config.ServerApp.TerminalManager
     assert terminal_mgr_config.cull_inactive_timeout == CULL_TIMEOUT


### PR DESCRIPTION
Suggested by @lp9052 in https://github.com/jupyter-server/jupyter_server_terminals/issues/85#issuecomment-1883917428

> by looking at the source code, it does respect the terminal config.
> 
> However, I believe it should update `termina_avaliable` to `False` instead of just return.
> 
> nbclassic actually read this field and will fail to launch if the value is missing.
> 
> I know they should have a default value for missing fields(issue raised). But I also believe it should be populated, instead of just missing.
> 
> Link to nbclassic issue: [jupyter/nbclassic#255](https://github.com/jupyter/nbclassic/issues/255)

this allows us to be consistent with Jupyter Server 1.x behaviour: https://github.com/jupyter-server/jupyter_server/blob/1.x/jupyter_server/serverapp.py#L363