### PR TITLE
allow async authorization

### DIFF
--- a/jupyter_server_terminals/handlers.py
+++ b/jupyter_server_terminals/handlers.py
@@ -13,6 +13,7 @@ from jupyter_server.base.websocket import WebSocketMixin
 from terminado.management import NamedTermManager
 from terminado.websocket import TermSocket as BaseTermSocket
 from tornado import web
+from jupyter_core.utils import ensure_async
 
 from .base import TerminalsMixin
 
@@ -48,7 +49,7 @@ class TermSocket(TerminalsMixin, WebSocketMixin, JupyterHandler, BaseTermSocket)
         if self.authorizer is None:
             # Warn if an authorizer is unavailable.
             warn_disabled_authorization()  # type:ignore[unreachable]
-        elif not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
+        elif not await ensure_async(self.authorizer.is_authorized(self, user, "execute", self.auth_resource)):
             raise web.HTTPError(403)
 
         if args[0] not in self.term_manager.terminals:  # type:ignore[attr-defined]

--- a/jupyter_server_terminals/handlers.py
+++ b/jupyter_server_terminals/handlers.py
@@ -13,7 +13,6 @@ from jupyter_server.base.websocket import WebSocketMixin
 from terminado.management import NamedTermManager
 from terminado.websocket import TermSocket as BaseTermSocket
 from tornado import web
-from jupyter_core.utils import ensure_async
 
 from .base import TerminalsMixin
 
@@ -49,7 +48,9 @@ class TermSocket(TerminalsMixin, WebSocketMixin, JupyterHandler, BaseTermSocket)
         if self.authorizer is None:
             # Warn if an authorizer is unavailable.
             warn_disabled_authorization()  # type:ignore[unreachable]
-        elif not await ensure_async(self.authorizer.is_authorized(self, user, "execute", self.auth_resource)):
+        elif not await ensure_async(
+            self.authorizer.is_authorized(self, user, "execute", self.auth_resource)
+        ):
             raise web.HTTPError(403)
 
         if args[0] not in self.term_manager.terminals:  # type:ignore[attr-defined]


### PR DESCRIPTION
Awhile back in Jupyter Server, we added [support for async authorizers](https://github.com/jupyter-server/jupyter_server/pull/1373). This PR updates jupyter_server_terminals to add this support too. Without this line, an async authorizer causes a:
```
`is_authorized` was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```