### PR TITLE
fix: preserve Windows terminal cwd with glob chars

### DIFF
--- a/jupyter_server_terminals/terminalmanager.py
+++ b/jupyter_server_terminals/terminalmanager.py
@@ -6,8 +6,10 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import os
 import typing as t
 from datetime import timedelta
+from pathlib import Path
 
 from jupyter_server._tz import isoformat, utcnow
 from jupyter_server.prometheus import metrics
@@ -20,6 +22,44 @@ from traitlets.config import LoggingConfigurable
 RUNNING_TOTAL = metrics.TERMINAL_CURRENTLY_RUNNING_TOTAL
 
 MODEL = t.Dict[str, t.Any]
+TERMINAL_CWD_ENV = "JUPYTER_SERVER_TERMINAL_CWD"
+POWERSHELL_COMMANDS = {"powershell.exe", "powershell", "pwsh.exe", "pwsh"}
+POWERSHELL_CONFLICTING_COMMAND_ARGS = {
+    "-command",
+    "/command",
+    "-encodedcommand",
+    "/encodedcommand",
+    "-file",
+    "/file",
+}
+POWERSHELL_LITERAL_CWD_COMMAND = (
+    f"if ($env:{TERMINAL_CWD_ENV}) {{ "
+    f"Set-Location -LiteralPath $env:{TERMINAL_CWD_ENV}; "
+    f"Remove-Item Env:{TERMINAL_CWD_ENV} "
+    "}"
+)
+
+
+def _powershell_arg_name(arg: str) -> str:
+    """Normalize a PowerShell argument for conflict detection."""
+    return arg.split(":", 1)[0].lower()
+
+
+def _powershell_command_with_literal_cwd(shell_command: t.Any) -> list[str] | None:
+    """Append a literal cwd command to PowerShell shell commands when it is safe."""
+    if not isinstance(shell_command, (list, tuple)) or not shell_command:
+        return None
+    if not all(isinstance(arg, str) for arg in shell_command):
+        return None
+    if Path(shell_command[0]).name.lower() not in POWERSHELL_COMMANDS:
+        return None
+    if any(
+        _powershell_arg_name(arg) in POWERSHELL_CONFLICTING_COMMAND_ARGS
+        for arg in shell_command[1:]
+    ):
+        return None
+
+    return [*shell_command, "-NoExit", "-Command", POWERSHELL_LITERAL_CWD_COMMAND]
 
 
 class TerminalManager(LoggingConfigurable, NamedTermManager):  # type:ignore[misc]
@@ -59,6 +99,19 @@ class TerminalManager(LoggingConfigurable, NamedTermManager):  # type:ignore[mis
         # Ensure culler is initialized
         self._initialize_culler()
         return model
+
+    def new_terminal(self, **kwargs: t.Any) -> PtyWithClients:
+        """Make a new terminal."""
+        cwd = kwargs.get("cwd")
+        if os.name == "nt" and cwd:
+            extra_env = dict(kwargs.get("extra_env") or {})
+            extra_env[TERMINAL_CWD_ENV] = str(cwd)
+            kwargs["extra_env"] = extra_env
+            shell_command = _powershell_command_with_literal_cwd(self.shell_command)
+            if shell_command is not None:
+                kwargs["shell_command"] = shell_command
+
+        return super().new_terminal(**kwargs)
 
     def get(self, name: str) -> MODEL:
         """Get terminal 'name'."""

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -9,6 +9,11 @@ import pytest
 from tornado.httpclient import HTTPClientError
 from traitlets.config.loader import Config
 
+from jupyter_server_terminals.terminalmanager import (
+    POWERSHELL_LITERAL_CWD_COMMAND,
+    _powershell_command_with_literal_cwd,
+)
+
 
 @pytest.fixture()
 def terminal_path(tmp_path):
@@ -23,6 +28,16 @@ def terminal_path(tmp_path):
 @pytest.fixture()
 def terminal_root_dir(jp_root_dir):
     subdir = jp_root_dir.joinpath("terminal_path")
+    subdir.mkdir()
+
+    yield subdir
+
+    shutil.rmtree(str(subdir), ignore_errors=True)
+
+
+@pytest.fixture()
+def terminal_root_dir_with_glob_chars(jp_root_dir):
+    subdir = jp_root_dir.joinpath("terminal[path]")
     subdir.mkdir()
 
     yield subdir
@@ -195,6 +210,53 @@ async def test_terminal_create_with_relative_cwd(
     assert expected in message_stdout
 
 
+async def test_terminal_create_with_relative_cwd_glob_chars(
+    jp_fetch, jp_ws_fetch, jp_root_dir, terminal_root_dir_with_glob_chars
+):
+    resp = await jp_fetch(
+        "api",
+        "terminals",
+        method="POST",
+        body=json.dumps({"cwd": str(terminal_root_dir_with_glob_chars.relative_to(jp_root_dir))}),
+        allow_nonstandard_methods=True,
+    )
+
+    data = json.loads(resp.body.decode())
+    term_name = data["name"]
+
+    while True:
+        try:
+            ws = await jp_ws_fetch("terminals", "websocket", term_name)
+            break
+        except HTTPClientError as e:
+            if e.code != 404:
+                raise
+            await asyncio.sleep(1)
+
+    ws.write_message(json.dumps(["stdin", "pwd\r\n"]))
+
+    message_stdout = ""
+    while True:
+        try:
+            message = await asyncio.wait_for(ws.read_message(), timeout=5.0)
+        except asyncio.TimeoutError:
+            break
+
+        message = json.loads(message)
+
+        if message[0] == "stdout":
+            message_stdout += message[1]
+
+    ws.close()
+
+    expected = (
+        terminal_root_dir_with_glob_chars.name
+        if sys.platform == "win32"
+        else str(terminal_root_dir_with_glob_chars)
+    )
+    assert expected in message_stdout
+
+
 async def test_terminal_create_with_bad_cwd(jp_fetch, jp_ws_fetch):
     non_existing_path = "/tmp/path/to/nowhere"  # noqa: S108
     resp = await jp_fetch(
@@ -234,6 +296,30 @@ async def test_terminal_create_with_bad_cwd(jp_fetch, jp_ws_fetch):
     ws.close()
 
     assert non_existing_path not in message_stdout
+
+
+def test_powershell_literal_cwd_command_allows_safe_shell_args():
+    shell_command = _powershell_command_with_literal_cwd(
+        ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo", "-NoProfile"]
+    )
+
+    assert shell_command == [
+        "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NoExit",
+        "-Command",
+        POWERSHELL_LITERAL_CWD_COMMAND,
+    ]
+
+
+@pytest.mark.parametrize("arg", ["-Command", "/command:print", "-File", "-EncodedCommand"])
+def test_powershell_literal_cwd_command_skips_conflicting_shell_args(arg):
+    assert _powershell_command_with_literal_cwd(["pwsh.exe", arg]) is None
+
+
+def test_powershell_literal_cwd_command_skips_non_powershell_shells():
+    assert _powershell_command_with_literal_cwd(["cmd.exe", "/K"]) is None
 
 
 async def test_app_config(jp_configurable_serverapp):


### PR DESCRIPTION
## Summary
- preserve the requested terminal cwd on Windows when the path contains PowerShell wildcard characters such as `[]`
- pass the validated cwd through a per-terminal environment variable and use `Set-Location -LiteralPath` for plain PowerShell launches
- add regression coverage for a relative cwd named `terminal[path]`

## Root cause
JupyterLab sends the requested `cwd` correctly, but on Windows the default PowerShell terminal can fall back to `System32` when the cwd contains wildcard characters. Starting PowerShell and then changing location with `-LiteralPath` preserves the exact directory without treating brackets as glob syntax.

## Testing
- `py -3.12 -m pytest -q tests/test_terminal.py`
- `python -m pytest -q tests/test_terminal.py::test_terminal_create_with_relative_cwd tests/test_terminal.py::test_terminal_create_with_relative_cwd_glob_chars tests/test_terminal.py::test_terminal_create_with_bad_cwd`
- `python -m ruff check jupyter_server_terminals/app.py jupyter_server_terminals/terminalmanager.py --select I,PTH`

Addresses jupyterlab/jupyterlab#18830